### PR TITLE
Lazy-load the model-viewer script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudfour/lite-model-viewer",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A lazy-loaded model-viewer web component",
   "author": "Cloud Four (http://cloudfour.com)",
   "homepage": "https://github.com/cloudfour/lite-model-viewer",


### PR DESCRIPTION
This PR updates our code to lazy-load the model-viewer script by waiting until the user clicks the preview, then injecting the script, and then loading the model.

## Testing

Review the preview deploy. Watch the network tab and confirm that you only see the `model-viewer.min.js` script load after clicking on a preview, and that it only loads once (if you click a second model, it doesn't load the script again).

---

Fixes #1